### PR TITLE
Sets EIP712TypedData.Domain properties to optional

### DIFF
--- a/Sources/MagicSDK/Modules/Web3/EIP712TypedData.swift
+++ b/Sources/MagicSDK/Modules/Web3/EIP712TypedData.swift
@@ -16,10 +16,11 @@ public struct EIP712TypedData: Codable, Equatable {
     }
 
     public struct Domain: Codable, Equatable {
-        let name: String
-        let version: String
+        let name: String?
+        let version: String?
         let chainId: Int?
-        let verifyingContract: String
+        let verifyingContract: String?
+        let salt: UInt32?
     }
 
     public let types: Dictionary<String, Array<Type>>


### PR DESCRIPTION
* Sets the properties of EIP712TypedData.Domain to be optional
* Adds `Salt` property as per doc:  https://eips.ethereum.org/EIPS/eip-712

`-  bytes32 salt -  an disambiguating salt for the protocol. This can be used as a domain separator of last resort.`

