### PR TITLE
Bump iOS min version in swift.package to v13

### DIFF
--- a/MagicSDK.podspec
+++ b/MagicSDK.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'MagicSDK'
-  s.version          = '7.0.1'
+  s.version          = '8.0.0'
   s.summary          = 'Magic IOS SDK'
 
   s.description      = <<-DESC

--- a/MagicSDK.podspec
+++ b/MagicSDK.podspec
@@ -16,7 +16,7 @@ TODO: Add long description of the pod here.
   s.source           = { :git => 'https://github.com/magiclabs/magic-ios.git', :tag => s.version.to_s }
   s.swift_version = '5.0'
   s.ios.deployment_target = '13.0'
-#   s.osx.deployment_target  = '10.12'
+#   s.osx.deployment_target  = '10.15'
 
   s.source_files = 'Sources/MagicSDK/**/*'
 

--- a/MagicSDK.podspec
+++ b/MagicSDK.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'MagicSDK'
-  s.version          = '7.0.0'
+  s.version          = '7.0.1'
   s.summary          = 'Magic IOS SDK'
 
   s.description      = <<-DESC
@@ -15,7 +15,7 @@ TODO: Add long description of the pod here.
   s.author           = { 'Jerry Liu' => 'jerry@magic.link' }
   s.source           = { :git => 'https://github.com/magiclabs/magic-ios.git', :tag => s.version.to_s }
   s.swift_version = '5.0'
-  s.ios.deployment_target = '10.0'
+  s.ios.deployment_target = '13.0'
 #   s.osx.deployment_target  = '10.12'
 
   s.source_files = 'Sources/MagicSDK/**/*'

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "MagicSDK",
     platforms: [
        .iOS(.v13),
-       .macOS(.v10_12)
+       .macOS(.v10_15)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "MagicSDK",
     platforms: [
-       .iOS(.v10),
+       .iOS(.v13),
        .macOS(.v10_12)
     ],
     products: [


### PR DESCRIPTION
Drops support for iOS versions 10, 11, 12 and close security vulnerabilities to zero-day exploits like [pegasus](https://en.wikipedia.org/wiki/Pegasus_(spyware)) 

Fixes Issue https://github.com/magiclabs/magic-ios-ext/issues/8



