### PR TITLE
Adds `isInspectable` check to WebViewController

### DIFF
--- a/MagicSDK.podspec
+++ b/MagicSDK.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'MagicSDK'
-  s.version          = '8.0.0'
+  s.version          = '8.0.1'
   s.summary          = 'Magic IOS SDK'
 
   s.description      = <<-DESC

--- a/Sources/MagicSDK/Core/Relayer/WebViewController.swift
+++ b/Sources/MagicSDK/Core/Relayer/WebViewController.swift
@@ -191,6 +191,10 @@ class WebViewController: UIViewController, WKUIDelegate, WKScriptMessageHandler,
             
             webView.uiDelegate = self
             
+            if #available(macOS 13.3, iOS 16.4, tvOS 16.4, *) {
+                webView.isInspectable = true
+            }
+            
             // conforming WKNavigationDelegate
             webView.navigationDelegate = self
             


### PR DESCRIPTION
[Update by Apple](https://webkit.org/blog/13936/enabling-the-inspection-of-web-content-in-apps/) in the latest versions of iOS turns this useful feature off by default. Let's turn it back on.