### PR TITLE
Open URL in Mobile Browser if `open_in_device_browser` Flag Is True

### DIFF
--- a/MagicSDK.podspec
+++ b/MagicSDK.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'MagicSDK'
-  s.version          = '8.0.1'
+  s.version          = '8.1.0'
   s.summary          = 'Magic IOS SDK'
 
   s.description      = <<-DESC

--- a/Sources/MagicSDK/Core/Relayer/WebViewController.swift
+++ b/Sources/MagicSDK/Core/Relayer/WebViewController.swift
@@ -224,6 +224,26 @@ class WebViewController: UIViewController, WKUIDelegate, WKScriptMessageHandler,
         } catch {}
     }
     
+    /**
+     * The WKWebView will call this method when a web application calls window.open() in JavaScript.
+     */
+    func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
+        // Make sure the URL is set.
+        guard let url = navigationAction.request.url,
+              let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: true),
+              let openInDeviceBrowser = urlComponents.queryItems?.first(where: { $0.name == "open_in_device_browser" })?.value?.lowercased()
+        else {
+            return nil
+        }
+        
+        if UIApplication.shared.canOpenURL(url) && openInDeviceBrowser == "true" {
+            // Open the link in the external browser.
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        }
+        
+        return nil
+    }
+    
     // handle external link clicked events
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
             // Check for links.


### PR DESCRIPTION
Utilizes WKWebView's `createWebViewWith` method to detect if a url opened via `window.open()` contains `open_in_device_browser` query and determine if link should be opened on device browser app. 

![2023-05-10 14 31 10](https://github.com/magiclabs/magic-ios/assets/13407884/45601ddb-7df1-4226-a6e8-8d61c05c1723)
