### PR TITLE
Tackle crash defensively in the case of an invalid signature of a keychain value

### DIFF
--- a/Sources/MagicSDK/Core/Relayer/Types/DPop.swift
+++ b/Sources/MagicSDK/Core/Relayer/Types/DPop.swift
@@ -62,7 +62,10 @@ func createJwt()  -> String?{
         let signingInput = headersB64 + "." + claimsB64
         let signingInputData = signingInput.data(using: .utf8)!
 
-        let signature = try! privateKey.signature(for: signingInputData)
+        guard let signature = try? privateKey.signature(for: signingInputData) else {
+            // This can happen when the [secure enclave biometrics](https://developer.apple.com/forums/thread/682162?answerId=726099022#726099022) have changed such as when an app is auto-installed on a new device
+            return nil
+        }
 
         let signatureB64 = base64UrlEncoded(signature.rawRepresentation)
 


### PR DESCRIPTION
We encounter a recurring crash on this implicitly unwrapped `try!`.
The cause, seems to be an [OS-bug](https://developer.apple.com/forums/thread/682162?answerId=726099022#726099022) that indicates the biometrics that are securing the keychain have changed, such as when an app is automatically restored on a new phone.

The throwing function that gets the `privateKey` does not throw in this situation but the signature is invalid so it crashes here.

The recommendation in the forum seems to be to delete the keychain value in this scenario, but I don't have sufficient context to know if what I do in this PR is sufficient to recreate the keychain value.

What I do know is that this error results in users being unable to use the app at all, until they uninstall + reinstall the app, which is a terrible user experience.
