### PR TITLE
Enable external dismissal

### DIFF
--- a/Sources/MagicSDK/Core/Magic.swift
+++ b/Sources/MagicSDK/Core/Magic.swift
@@ -34,21 +34,24 @@ public class Magic: NSObject {
     ///   - ethNetwork: Etherum Network setting (ie. mainnet or goerli)
     ///   - customNode: A custom RPC node
     ///   - viewHostProvider: An optional `UIViewController` provider for login views to embed within
-    public convenience init(apiKey: String, ethNetwork: EthNetwork, locale: String = Locale.current.identifier, viewHostProvider: MagicViewHostProviding? = nil) {
-        self.init(urlBuilder: URLBuilder(apiKey: apiKey, network: ethNetwork, locale: locale), viewHostProvider: viewHostProvider)
+    public convenience init(apiKey: String, ethNetwork: EthNetwork, locale: String = Locale.current.identifier) {
+        self.init(urlBuilder: URLBuilder(apiKey: apiKey, network: ethNetwork, locale: locale))
     }
 
-    public convenience init(apiKey: String, customNode: CustomNodeConfiguration, locale: String = Locale.current.identifier, viewHostProvider: MagicViewHostProviding? = nil) {
-        self.init(urlBuilder: URLBuilder(apiKey: apiKey, customNode: customNode, locale: locale), viewHostProvider: viewHostProvider)
+    public convenience init(apiKey: String, customNode: CustomNodeConfiguration, locale: String = Locale.current.identifier) {
+        self.init(urlBuilder: URLBuilder(apiKey: apiKey, customNode: customNode, locale: locale))
     }
 
-    public convenience init(apiKey: String, locale: String = Locale.current.identifier, viewHostProvider: MagicViewHostProviding? = nil) {
-        self.init(urlBuilder: URLBuilder(apiKey: apiKey, network: EthNetwork.mainnet, locale: locale), viewHostProvider: viewHostProvider)
+    public convenience init(apiKey: String, locale: String = Locale.current.identifier) {
+        self.init(urlBuilder: URLBuilder(apiKey: apiKey, network: EthNetwork.mainnet, locale: locale))
+    }
+
+    public convenience init(apiKey: String, locale: String = Locale.current.identifier, viewHostProvider: MagicViewHostProviding) {
+        self.init(urlBuilder: URLBuilder(apiKey: apiKey, locale: locale), viewHostProvider: viewHostProvider)
     }
 
     /// Core constructor
-    private init(urlBuilder: URLBuilder, viewHostProvider: MagicViewHostProviding?) {
-        let viewHostProvider = viewHostProvider ?? MagicViewHostProvider()
+    private init(urlBuilder: URLBuilder, viewHostProvider: MagicViewHostProviding = MagicViewHostProvider()) {
         self.rpcProvider = RpcProvider(urlBuilder: urlBuilder, viewHostProvider: viewHostProvider)
 
         self.user = UserModule(rpcProvider: self.rpcProvider)

--- a/Sources/MagicSDK/Core/Magic.swift
+++ b/Sources/MagicSDK/Core/Magic.swift
@@ -13,14 +13,14 @@ import WebKit
 public class Magic: NSObject {
     // MARK: - Log Message Warning
     public let MA_EXTENSION_ONLY_MSG = "This extension only works with Magic Auth API Keys"
-    
+
     // MARK: - Modules
     public let user: UserModule
     public let auth: AuthModule
     public let wallet: WalletModule
-    
+
     // MARK: - Property
-   public var rpcProvider: RpcProvider
+    public var rpcProvider: RpcProvider
 
     /// Shared instance of `Magic`
     public static var shared: Magic!
@@ -32,28 +32,30 @@ public class Magic: NSObject {
     /// - Parameters:
     ///   - apiKey: Your client ID. From https://dashboard.Magic.com
     ///   - ethNetwork: Etherum Network setting (ie. mainnet or goerli)
-    ///   - customNode: A custom RPC node 
-    public convenience init(apiKey: String, ethNetwork: EthNetwork, locale: String = Locale.current.identifier) {
-        self.init(urlBuilder: URLBuilder(apiKey: apiKey, network: ethNetwork, locale: locale))
+    ///   - customNode: A custom RPC node
+    ///   - viewHostProvider: An optional `UIViewController` provider for login views to embed within
+    public convenience init(apiKey: String, ethNetwork: EthNetwork, locale: String = Locale.current.identifier, viewHostProvider: MagicViewHostProviding? = nil) {
+        self.init(urlBuilder: URLBuilder(apiKey: apiKey, network: ethNetwork, locale: locale), viewHostProvider: viewHostProvider)
     }
 
-    public convenience init(apiKey: String, customNode: CustomNodeConfiguration, locale: String = Locale.current.identifier) {
-        self.init(urlBuilder: URLBuilder(apiKey: apiKey, customNode: customNode, locale: locale))
+    public convenience init(apiKey: String, customNode: CustomNodeConfiguration, locale: String = Locale.current.identifier, viewHostProvider: MagicViewHostProviding? = nil) {
+        self.init(urlBuilder: URLBuilder(apiKey: apiKey, customNode: customNode, locale: locale), viewHostProvider: viewHostProvider)
     }
 
-    public convenience init(apiKey: String, locale: String = Locale.current.identifier) {
-        self.init(urlBuilder: URLBuilder(apiKey: apiKey, network: EthNetwork.mainnet, locale: locale))
+    public convenience init(apiKey: String, locale: String = Locale.current.identifier, viewHostProvider: MagicViewHostProviding? = nil) {
+        self.init(urlBuilder: URLBuilder(apiKey: apiKey, network: EthNetwork.mainnet, locale: locale), viewHostProvider: viewHostProvider)
     }
 
     /// Core constructor
-    private init(urlBuilder: URLBuilder) {
-         self.rpcProvider = RpcProvider(urlBuilder: urlBuilder)
-        
-         self.user = UserModule(rpcProvider: self.rpcProvider)
-         self.auth = AuthModule(rpcProvider: self.rpcProvider)
-         self.wallet = WalletModule(rpcProvider: self.rpcProvider)
-        
-         super.init()
+    private init(urlBuilder: URLBuilder, viewHostProvider: MagicViewHostProviding?) {
+        let viewHostProvider = viewHostProvider ?? MagicViewHostProvider()
+        self.rpcProvider = RpcProvider(urlBuilder: urlBuilder, viewHostProvider: viewHostProvider)
+
+        self.user = UserModule(rpcProvider: self.rpcProvider)
+        self.auth = AuthModule(rpcProvider: self.rpcProvider)
+        self.wallet = WalletModule(rpcProvider: self.rpcProvider)
+
+        super.init()
     }
 }
 

--- a/Sources/MagicSDK/Core/Provider/MagicViewHostProvider.swift
+++ b/Sources/MagicSDK/Core/Provider/MagicViewHostProvider.swift
@@ -1,0 +1,39 @@
+//
+//  MagicViewHostProvider.swift
+//  
+//
+//  Created by Tristan Warner-Smith on 27/02/2024.
+//
+
+import UIKit
+
+public protocol MagicViewHostProviding {
+    func provide() throws -> UIViewController
+}
+
+struct MagicViewHostProvider: MagicViewHostProviding {
+    public init() {}
+
+    func provide() throws -> UIViewController {
+        let window = try keyWindow()
+        // Find topmost view controller from the hierarchy and move webview to it
+        if var topController = window.rootViewController {
+            while let presentedViewController = topController.presentedViewController {
+                topController = presentedViewController
+            }
+            return topController
+        } else {
+            throw WebViewController.AuthRelayerError.topMostWindowNotFound
+        }
+    }
+}
+
+private extension MagicViewHostProvider {
+    func keyWindow() throws -> UIWindow {
+        guard let window = UIApplication.shared.windows.filter({ $0.isKeyWindow}).first else {
+            throw WebViewController.AuthRelayerError.topMostWindowNotFound
+        }
+
+        return window
+    }
+}

--- a/Sources/MagicSDK/Core/Provider/RpcProvider.swift
+++ b/Sources/MagicSDK/Core/Provider/RpcProvider.swift
@@ -24,16 +24,18 @@ public class RpcProvider: NetworkClient, Web3Provider {
         /// Missing callback
         case missingPayloadCallback(json: String)
     }
-    
+
+    var webViewPresenter: WebViewControllerPresenting { overlay }
+
     let overlay: WebViewController
     public let urlBuilder: URLBuilder
     
-    required init(urlBuilder: URLBuilder) {
-        self.overlay = WebViewController(url: urlBuilder)
+    required init(urlBuilder: URLBuilder, viewHostProvider: MagicViewHostProviding) {
+        self.overlay = WebViewController(url: urlBuilder, viewHostProvider: viewHostProvider)
         self.urlBuilder = urlBuilder
         super.init()
     }
-    
+
     // MARK: - Sending Requests
     
     /// Sends an RPCRequest and parses the result

--- a/Sources/MagicSDK/Core/Relayer/WebViewController.swift
+++ b/Sources/MagicSDK/Core/Relayer/WebViewController.swift
@@ -279,6 +279,8 @@ class WebViewController: UIViewController, WKUIDelegate, WKScriptMessageHandler,
     }
 }
 
+// MARK: - Presentation
+
 extension WebViewController: WebViewControllerPresenting {
     func show() throws {
         let isAlreadyAttached = try isAttached()
@@ -295,6 +297,8 @@ extension WebViewController: WebViewControllerPresenting {
         try detachWebView()
     }
 }
+
+// MARK: - View Hierarchy Helpers
 
 private extension WebViewController {
     func isAttached() throws -> Bool {

--- a/Sources/MagicSDK/Core/Relayer/WebViewController.swift
+++ b/Sources/MagicSDK/Core/Relayer/WebViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 
 public protocol WebViewControllerPresenting {
     func show() throws
-    func hide() throws
+    func hide(remove: Bool) throws
 }
 
 /// An instance of the Fortmatc Phantom WebView
@@ -284,17 +284,19 @@ class WebViewController: UIViewController, WKUIDelegate, WKScriptMessageHandler,
 extension WebViewController: WebViewControllerPresenting {
     func show() throws {
         let isAlreadyAttached = try isAttached()
-        let container = try viewHostProvider.provide()
-        
         if !isAlreadyAttached {
             try attachWebView()
         }
 
-        container.view.bringSubviewToFront(view)
+        try bringToFront()
     }
 
-    func hide() throws {
-        try detachWebView()
+    func hide(remove: Bool = false) throws {
+        if remove {
+            try detachWebView()
+        } else {
+            try sendToBack()
+        }
     }
 }
 
@@ -318,7 +320,16 @@ private extension WebViewController {
 
     func detachWebView() throws {
         guard try isAttached() else { return }
-        view.superview?.sendSubviewToBack(view)
+        try sendToBack()
         view.removeFromSuperview()
+    }
+
+    func bringToFront() throws {
+        view.superview?.bringSubviewToFront(view)
+    }
+
+    func sendToBack() throws {
+        guard try isAttached() else { return }
+        view.superview?.sendSubviewToBack(view)
     }
 }

--- a/Sources/MagicSDK/Modules/Auth/AuthModule.swift
+++ b/Sources/MagicSDK/Modules/Auth/AuthModule.swift
@@ -53,7 +53,7 @@ public class AuthModule: BaseModule {
         }
     }
 
-    public func cancelLogin() {
+    public func cancelLogin(remove: Bool = false) {
         if #available(iOS 14.0, *) {
             AuthModule.logger.warning("cancelLogin: \(BaseWarningLog.MA_Method)")
         } else {
@@ -61,7 +61,7 @@ public class AuthModule: BaseModule {
         }
 
         do {
-            try self.provider.webViewPresenter.hide()
+            try self.provider.webViewPresenter.hide(remove: remove)
         } catch let error {
             debugPrint("Failed to dismiss login view due to \(error.localizedDescription)")
         }

--- a/Sources/MagicSDK/Modules/Auth/AuthModule.swift
+++ b/Sources/MagicSDK/Modules/Auth/AuthModule.swift
@@ -52,7 +52,21 @@ public class AuthModule: BaseModule {
             loginWithEmailOTP(configuration, response: promiseResolver(resolver))
         }
     }
-    
+
+    public func cancelLogin() {
+        if #available(iOS 14.0, *) {
+            AuthModule.logger.warning("cancelLogin: \(BaseWarningLog.MA_Method)")
+        } else {
+            print("cancelLogin: \(BaseWarningLog.MA_Method)")
+        }
+
+        do {
+            try self.provider.webViewPresenter.hide()
+        } catch let error {
+            debugPrint("Failed to dismiss login view due to \(error.localizedDescription)")
+        }
+    }
+
     public enum LoginEmailOTPLinkEvent: String {
         case emailNotDeliverable = "email-not-deliverable"
         case emailSent = "email-sent"


### PR DESCRIPTION
### Feature
Enables external control over the view container in order to enable external dismissal and control of the container. With this approach, a client can give the Magic SDK a ViewController in which to nest itself.

### Scope
* Enables clients to provide the container in which the `WebViewController` is added
* Enables external dismissal of the login flow
* **NOTE:** Swaps from simply moving the `WebViewController` to the back (keeping it in the view hierarchy forever) to removing it from the view hierarchy entirely. I'm not sure if there are any other scenarios where this change can be problematic, so you might want to manage this differently.

In our case we have a `SwiftUI` app so in order to drive this we need to create a view container, but we need to be able to control the display more directly and dismiss the popup according to our logic.

### Tradeoffs
* Adds calculated `webViewPresenter: WebViewControllerPresenting` called from `AuthModule.cancelLogin` , rather than encapsulating all the APIs called on `WebViewController` and re-exposing the `WebViewController` by protocols instead
* Couldn't think of a better name for `AuthModule.cancelLogin`
* Added code should pass SwiftLint rules but the default SwiftLint rules raise too many issues against the current code so I didn't want to enlarge the scope and address those too.
* Ran out of time to test many scenarios so the default seems to work fine but there's a chance that `WebViewController` would need to change its constraint code when presented in different containers.