### PR TITLE
Prevent Crash for Device Swapping Users via Regeneration of PK

### DIFF
--- a/MagicSDK.podspec
+++ b/MagicSDK.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'MagicSDK'
-  s.version          = '10.1.0'
+  s.version          = '10.1.1'
   s.summary          = 'Magic IOS SDK'
 
   s.description      = <<-DESC

--- a/Sources/MagicSDK/Core/Relayer/Types/DPop.swift
+++ b/Sources/MagicSDK/Core/Relayer/Types/DPop.swift
@@ -17,66 +17,72 @@ func base64UrlEncoded(_ data: Data) -> String {
     return b64
 }
 
-func createJwt()  -> String?{
-    var error: Unmanaged<CFError>?
 
-    do {
-        let privateKey = try retrieveKeyFromKeyChain()
+func createJwt() -> String? {
+    var attempts = 0
+    
+    while attempts < 3 { // Attempt the retry flow at a maximum of 3 times before giving up
+        do {
+            let privateKey = try retrieveKeyFromKeyChain()
+            
+            // Get the public key.
+            let publicKey = privateKey.publicKey
+            
+            // Get the raw representation of the public key.
+            let rawPublicKey = publicKey.rawRepresentation
+            
+            // Extract the x and y coordinates.
+            let xCoordinateData = rawPublicKey[1..<33]
+            let yCoordinateData = rawPublicKey[33..<65]
+            
+            // If you need base64-encoded strings for JWK:
+            let xCoordinateBase64 = base64UrlEncoded(xCoordinateData)
+            let yCoordinateBase64 = base64UrlEncoded(yCoordinateData)
+            
+            // Convert the public key to JWK format.
+            // construct headers
+            var headers: [String: Any] = ["typ": "dpop+jwt", "alg": "ES256"]
+            headers["jwk"] = [
+                "kty": "EC",
+                "crv": "P-256",
+                "x": xCoordinateBase64,
+                "y": yCoordinateBase64
+            ] as [String : Any]
 
-        // Get the public key.
-        let publicKey = privateKey.publicKey
+            let headersData = try JSONSerialization.data(withJSONObject: headers)
+            let headersB64 = base64UrlEncoded(headersData)
+            
+            // construct claims
+            let iat = Int(Date().timeIntervalSince1970)
+            let jti = UUID().uuidString.lowercased()
 
-        // Get the raw representation of the public key.
-        let rawPublicKey = publicKey.rawRepresentation
+            let claims: [String: Any] = ["iat": iat, "jti": jti]
+            let claimsData = try JSONSerialization.data(withJSONObject: claims)
+            let claimsB64 = base64UrlEncoded(claimsData)
+            
+            /// sign
+            let signingInput =  headersB64 + "." + claimsB64
+            
+            guard let signingInputData = signingInput.data(using: .utf8),
+                  let signature = try? privateKey.signature(for: signingInputData) else {
+                // This can happen when the [secure enclave biometrics](https://developer.apple.com/forums/thread/682162?answerId=726099022#726099022) 
+                // have changed such as when an app is auto-installed on a new device, ergo delete previously created key and try again
+                try deleteKeyFromKeyChain()
+                attempts += 1
+                continue
+            }
 
-        // Extract the x and y coordinates.
-        let xCoordinateData = rawPublicKey[1..<33]
-        let yCoordinateData = rawPublicKey[33..<65]
+            let signatureB64 = base64UrlEncoded(signature.rawRepresentation)
+            let jwt = signingInput + "." + signatureB64
+            
+            return jwt
 
-        // If you need base64-encoded strings for JWK:
-        let xCoordinateBase64 = base64UrlEncoded(xCoordinateData)
-        let yCoordinateBase64 = base64UrlEncoded(yCoordinateData)
-        // Convert the public key to JWK format.
-        // construct headers
-        var headers: [String: Any] = ["typ": "dpop+jwt", "alg": "ES256"]
-        headers["jwk"]  = [
-            "kty": "EC",
-            "crv": "P-256",
-            "x": xCoordinateBase64,
-            "y": yCoordinateBase64
-        ] as [String : Any]
-
-         let headersData = try JSONSerialization.data(withJSONObject: headers)
-         let headersB64 = base64UrlEncoded(headersData)
-
-
-        // construct claims
-        let iat = Int(Date().timeIntervalSince1970)
-        let jti = UUID().uuidString.lowercased()
-
-        let claims: [String: Any] = ["iat": iat, "jti": jti]
-        let claimsData = try JSONSerialization.data(withJSONObject: claims)
-        let claimsB64 = base64UrlEncoded(claimsData)
-
-        /// sign
-        let signingInput = headersB64 + "." + claimsB64
-        let signingInputData = signingInput.data(using: .utf8)!
-
-        guard let signature = try? privateKey.signature(for: signingInputData) else {
-            // This can happen when the [secure enclave biometrics](https://developer.apple.com/forums/thread/682162?answerId=726099022#726099022) have changed such as when an app is auto-installed on a new device
-            return nil
+        } catch {
+            // Handle error (log, throw, or break as necessary)
+            print("An error occurred: \(error)")
+            break
         }
-
-        let signatureB64 = base64UrlEncoded(signature.rawRepresentation)
-
-        let jwt = signingInput + "." + signatureB64
-
-        return jwt
-
-    } catch {
-        // silently handled error
-        return nil
     }
-
+    return nil // Return nil if unable to generate JWT after 3x retries
 }
 

--- a/Sources/MagicSDK/Utilities/SEKP.swift
+++ b/Sources/MagicSDK/Utilities/SEKP.swift
@@ -69,6 +69,17 @@ func retrieveKeyFromKeyChain () throws -> SecureEnclave.P256.Signing.PrivateKey 
     }
 }
 
+func deleteKeyFromKeyChain() throws {
+    let query = [kSecClass: kSecClassGenericPassword,
+                 kSecAttrAccount: account,
+                 kSecUseDataProtectionKeychain: true] as [String: Any]
+
+    let status = SecItemDelete(query as CFDictionary)
+    guard status == errSecSuccess || status == errSecItemNotFound else {
+        throw SEKPError.KeyStoreError("Unable to delete item: \(status.description)")
+    }
+}
+
 
 protocol GenericPasswordConvertible: CustomStringConvertible {
     /// Creates a key from a raw representation.


### PR DESCRIPTION
A minority of our developer's users are running into [this crash](https://github.com/magiclabs/magic-ios/issues/36) when swapping devices and restoring their Magic SDK backed apps from the keychain. 

As suggest in [Apple forums](https://developer.apple.com/forums/thread/682162?answerId=726099022#726099022) this update permits our SDK to attempt to recreate the key 3x times to give these users an avenue to recover. 