### PR TITLE
Adds `customViewWrapper` optional to Magic SDK to Permit External Actions

### DIFF
--- a/MagicSDK.podspec
+++ b/MagicSDK.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'MagicSDK'
-  s.version          = '10.1.1'
+  s.version          = '10.2.1'
   s.summary          = 'Magic IOS SDK'
 
   s.description      = <<-DESC

--- a/Sources/MagicSDK/Core/Magic.swift
+++ b/Sources/MagicSDK/Core/Magic.swift
@@ -33,6 +33,7 @@ public class Magic: NSObject {
     ///   - apiKey: Your client ID. From https://dashboard.Magic.com
     ///   - ethNetwork: Etherum Network setting (ie. mainnet or goerli)
     ///   - customNode: A custom RPC node 
+    ///   - customViewWrapper: An  custom `UIViewController` to act as the wrapping container of Magic's WebView
     public convenience init(apiKey: String, ethNetwork: EthNetwork, locale: String = Locale.current.identifier) {
         self.init(urlBuilder: URLBuilder(apiKey: apiKey, network: ethNetwork, locale: locale))
     }
@@ -40,14 +41,18 @@ public class Magic: NSObject {
     public convenience init(apiKey: String, customNode: CustomNodeConfiguration, locale: String = Locale.current.identifier) {
         self.init(urlBuilder: URLBuilder(apiKey: apiKey, customNode: customNode, locale: locale))
     }
+    
+    public convenience init(apiKey: String, customViewWrapper: UIViewController, locale: String = Locale.current.identifier) {
+        self.init(urlBuilder: URLBuilder(apiKey: apiKey, locale: locale), customViewWrapper: customViewWrapper)
+    }
 
     public convenience init(apiKey: String, locale: String = Locale.current.identifier) {
         self.init(urlBuilder: URLBuilder(apiKey: apiKey, network: EthNetwork.mainnet, locale: locale))
     }
 
     /// Core constructor
-    private init(urlBuilder: URLBuilder) {
-         self.rpcProvider = RpcProvider(urlBuilder: urlBuilder)
+    private init(urlBuilder: URLBuilder, customViewWrapper: UIViewController? = nil) {
+        self.rpcProvider = RpcProvider(urlBuilder: urlBuilder, customViewWrapper: customViewWrapper)
         
          self.user = UserModule(rpcProvider: self.rpcProvider)
          self.auth = AuthModule(rpcProvider: self.rpcProvider)

--- a/Sources/MagicSDK/Core/Provider/RpcProvider.swift
+++ b/Sources/MagicSDK/Core/Provider/RpcProvider.swift
@@ -28,8 +28,8 @@ public class RpcProvider: NetworkClient, Web3Provider {
     let overlay: WebViewController
     public let urlBuilder: URLBuilder
     
-    required init(urlBuilder: URLBuilder) {
-        self.overlay = WebViewController(url: urlBuilder)
+    required init(urlBuilder: URLBuilder, customViewWrapper: UIViewController? = nil) {
+        self.overlay = WebViewController(url: urlBuilder, customViewWrapper: customViewWrapper)
         self.urlBuilder = urlBuilder
         super.init()
     }

--- a/Sources/MagicSDK/Core/Provider/RpcProvider.swift
+++ b/Sources/MagicSDK/Core/Provider/RpcProvider.swift
@@ -76,7 +76,7 @@ public class RpcProvider: NetworkClient, Web3Provider {
         }.catch { error in
             let errResponse = Web3Response<Result>(error: ProviderError.encodingFailed(error))
             response(errResponse)
-//            handleRollbarError(error, log: false)
+
         }
     }
 }

--- a/Sources/MagicSDK/Core/Relayer/WebViewController.swift
+++ b/Sources/MagicSDK/Core/Relayer/WebViewController.swift
@@ -25,6 +25,7 @@ class WebViewController: UIViewController, WKUIDelegate, WKScriptMessageHandler,
         case messageEncodeFailed(message: String)
 
         case webviewAttachedFailed
+        case customViewNotFound
         case topMostWindowNotFound
     }
 
@@ -43,12 +44,16 @@ class WebViewController: UIViewController, WKUIDelegate, WKScriptMessageHandler,
     /// Queue and callbackss
     var queue: [String] = []
     var messageHandlers: Dictionary<Int, MessageHandler> = [:]
+    
+    var customViewWrapper: UIViewController?
 
     typealias MessageHandler = (String) throws ->  Void
 
     // MARK: - init
-    init(url: URLBuilder) {
+    init(url: URLBuilder, customViewWrapper: UIViewController? = nil) {
         self.urlBuilder = url
+        self.customViewWrapper = customViewWrapper
+        
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -241,6 +246,21 @@ class WebViewController: UIViewController, WKUIDelegate, WKScriptMessageHandler,
     override func viewDidLoad() {
         super.viewDidLoad()
         webView.scrollView.delegate = self // disable zoom
+        
+        if let customViewWrapper = customViewWrapper {
+            // Add webView as a subview of the custom wrapper's view
+            customViewWrapper.view.addSubview(webView)
+            loadWebViewContent()
+        } else {
+            loadWebViewContent()
+        }
+    }
+    
+    private func loadWebViewContent() {
+        if let url = URL(string: urlBuilder.url) {
+            let request = URLRequest(url: url)
+            webView.load(request)
+        }
     }
 
     /// Check did finished navigating, conforming WKNavigationDelegate

--- a/Sources/MagicSDK/Core/Relayer/WebViewController.swift
+++ b/Sources/MagicSDK/Core/Relayer/WebViewController.swift
@@ -365,6 +365,15 @@ class WebViewController: UIViewController, WKUIDelegate, WKScriptMessageHandler,
             throw AuthRelayerError.webviewAttachedFailed
         }
     }
+    
+    func detachWebViewFromCustomView() throws {
+        if customViewWrapper != nil {
+            webView.removeFromSuperview()
+        } else {
+            print("Please make sure you have provided Magic with a custom UIViewController to use this method.")
+            throw AuthRelayerError.customViewNotFound
+        }
+    }
 }
 
 

--- a/Sources/MagicSDK/Modules/Auth/AuthModule.swift
+++ b/Sources/MagicSDK/Modules/Auth/AuthModule.swift
@@ -35,6 +35,15 @@ public class AuthModule: BaseModule {
         }
     }
     
+    // MARK: - External Dismiss WebView
+    public func externalDismissLoginView() {
+        do {
+            try self.provider.overlay.detachWebViewFromCustomView()
+        } catch let error {
+            debugPrint("Failed to dismiss login view due to \(error.localizedDescription)")
+        }
+    }
+    
     public enum LoginEmailOTPLinkEvent: String {
         case emailNotDeliverable = "email-not-deliverable"
         case emailSent = "email-sent"


### PR DESCRIPTION
Adds a `customViewWrapper` optional parameter to the Magic SDK to allow developers to pass in their own `UIViewController` and permit them to setup custom actions like dismiss Magic's Webview with external methods like `externalDismissLoginView` as requested in PR https://github.com/magiclabs/magic-ios/pull/39